### PR TITLE
Add v.any primitive validator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## HEAD
+
+- Add `v.any` primitive validator.
+
 ## 0.1.0
 
 - Start this log.

--- a/README.md
+++ b/README.md
@@ -179,6 +179,18 @@ v.assert(v.equal(5), { apiName: "Validator" })(10); // Error: Validator: value m
 
 ## Primitive Validators
 
+### v.any
+
+This is mostly useful in combination with a higher-order validator like [`v.arrayOf`](#varrayofvalidator);
+
+```javascript
+const assert = v.assert(v.any);
+assert(false); // pass
+assert("str"); // pass
+assert(8); // pass
+assert([1, 2, 3]); // pass
+```
+
 ### v.boolean
 
 ```javascript

--- a/lib/index.js
+++ b/lib/index.js
@@ -212,6 +212,10 @@ v.range = function range(compareWith) {
  *
  * simple validators which return a string or undefined
  */
+v.any = function any() {
+  return;
+}
+
 v.boolean = function boolean(value) {
   if (typeof value !== 'boolean') {
     return 'boolean';

--- a/lib/index.test.js
+++ b/lib/index.test.js
@@ -517,6 +517,18 @@ describe('v.number', () => {
   });
 });
 
+describe('v.any', () => {
+  var check = t(v.any);
+  test('accepts everything', () => {
+    expect(check('str')).toBeUndefined();
+    expect(check(7)).toBeUndefined();
+    expect(check(true)).toBeUndefined();
+    expect(check(new Date())).toBeUndefined();
+    expect(check({})).toBeUndefined();
+    expect(check([1, 2, 3])).toBeUndefined();
+  });
+});
+
 describe('v.boolean', () => {
   var check = t(v.boolean);
   test('rejects strings', () => {


### PR DESCRIPTION
I found myself needing an all-accepting validator for situations in which I can't effectively describe the type of an array item or object property value, e.g. `v.arrayOf(v.any)`.