### PR TITLE
Rename apiName to description and use string arg for it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## HEAD
 
 - Add `v.nonEmptyString` primitive validator.
+- Rename `options.apiName` to `options.description`. (`options.apiName` still works but is deprecated.)
+- Allow the second argument to `v.assert` to be a string, which is interpreted as `options.description`.
 
 ## 0.4.0
 

--- a/README.md
+++ b/README.md
@@ -174,8 +174,8 @@ Returns a function which accepts an input value to be validated. This function t
 **Parameters**
 
 - `rootValidator`: The root validator to assert values with.
-- `options`: An options object.
-- `options.apiName`: String to prefix every error message with.
+- `options`: An options object or a string. If it is a string, it will be interpreted as `options.description`.
+- `options.description`: A string to prefix every error message with. For example, if `description` is `myFunc` and a string is invalid, the error message with be `myFunc: value must be a string`. (Formerly `options.apiName`, which works the same but is deprecated.)
 
 ```javascript
 v.assert(v.equal(5))(5); // undefined

--- a/README.md
+++ b/README.md
@@ -179,7 +179,8 @@ Returns a function which accepts an input value to be validated. This function t
 
 ```javascript
 v.assert(v.equal(5))(5); // undefined
-v.assert(v.equal(5), { apiName: "Validator" })(10); // Error: Validator: value must be a 5.
+v.assert(v.equal(5), { description: "myFunction" })(10); // Error: myFunction: value must be 5.
+v.assert(v.equal(5), 'Price')(10); // Error: Price: value must be 5.
 ```
 
 ## Primitive Validators

--- a/lib/index.js
+++ b/lib/index.js
@@ -20,6 +20,11 @@ var v = {};
  */
 v.assert = function(rootValidator, options) {
   options = options || {};
+  if (typeof options === 'string') {
+    options = { description: options };
+  }
+  var description = options.description || options.apiName;
+
   return function(value) {
     var message = validate(rootValidator, value);
     // all good
@@ -29,8 +34,8 @@ v.assert = function(rootValidator, options) {
 
     var errorMessage = processMessage(message, options);
 
-    if (options.apiName) {
-      errorMessage = options.apiName + ': ' + errorMessage;
+    if (description) {
+      errorMessage = description + ': ' + errorMessage;
     }
 
     throw new Error(errorMessage);

--- a/lib/index.test.js
+++ b/lib/index.test.js
@@ -1050,3 +1050,13 @@ test('type description contains its own article', () => {
   var check = v.assert(validator);
   expect(() => check('xx')).toThrowError('value must be an hour');
 });
+
+test('description provided as a string ', () => {
+  var check = v.assert(v.number, 'arg');
+  expect(() => check('xx')).toThrowError('arg: value must be a number');
+});
+
+test('description provided as an option ', () => {
+  var check = v.assert(v.number, { description: 'arg' });
+  expect(() => check('xx')).toThrowError('arg: value must be a number');
+});


### PR DESCRIPTION
Closes #25.

I tried to go down the path of making error messages like `arg must be a string` (instead of `arg: value must be a string`), but that turned out to be more complex than I wanted to deal with at the moment. I think it's acceptable to just use description/apiName for a colon-prefixed label.

@kepta for review, please.